### PR TITLE
Fix: Make operationId optional

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.7.3"
+version = "0.7.4"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/python/src/jentic/models.py
+++ b/python/src/jentic/models.py
@@ -42,7 +42,7 @@ class WorkflowEntry(BaseModel):
 class OperationEntry(BaseModel):
     id: str
     api_version_id: str
-    operation_id: str
+    operation_id: Optional[str] = None
     path: str
     method: str
     summary: Optional[str] = None


### PR DESCRIPTION
`operationId` is not guaranteed to be returned and it is not a required field. Make optional in model so that it does not cause failures when missing.