### PR TITLE
Feature: Submit Feedback Tool

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.2"
+version = "0.6.3"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.1"
+version = "0.6.2"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.5"
+    "jentic >=0.7.6"
 ]
 requires-python = ">=3.10"
 readme = "README.md"
@@ -23,6 +23,7 @@ license = {text = "MIT"}
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio",
+    "pytest-mock>=3.12.0",
     "ruff>=0.1.0",
     "black>=23.0.0",
     "isort>=5.0.0",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.3"
+version = "0.6.2"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -196,6 +196,14 @@ class MCPAdapter:
             logger.error("Missing or invalid 'feedback_data' in request for submit_feedback")
             return {"result": {"success": False, "message": "Missing or invalid 'feedback_data' parameter."}}
 
+        # Source user JENTIC_UUID from environment to pass in the feedback.
+        env_jentic_uuid = os.environ.get("JENTIC_UUID")
+        if env_jentic_uuid:
+            feedback_data['jentic_uuid'] = env_jentic_uuid
+            logger.info(f"JENTIC_UUID ('{env_jentic_uuid}') from environment ensured in feedback_data.")
+        else:
+            logger.debug("JENTIC_UUID not found in environment and not provided by agent. It will not be included.")
+
         feedback_endpoint_url = os.environ.get("FEEDBACK_ENDPOINT_URL", "https://xze2r4egy7.execute-api.eu-west-1.amazonaws.com/dev/workflow-feedback")
         logger.info(f"Submitting feedback to {feedback_endpoint_url}: {feedback_data}")
 

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -112,11 +112,13 @@ class MCPAdapter:
             {
                 "tool_name": "submit_feedback",
                 "description": (
-                    "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Always show user the full feedback information being sent before calling the submit_feedback tool. "
-                    "Make sure there is no sensitive information in the feedback like API Keys etc. "
-                    "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) "
-                    "and additional comments to be sent as part of the feedback. "
-                    "Pass the entire error message json from execute tool call response in the error field in submit_feedback tool call"
+                    "Ask the user for permission to submit feedback, which includes reporting details of the error to Jentic for analysis."
+                    "Before calling the submit_feedback tool, always show the user the full feedback content that will be sent."
+                    "Ensure that NO SENSITIVE information (e.g., API keys, access tokens) is present in the feedback. If such information is detected in the error message, REMOVE it before proceeding."
+                    "Include the error message JSON from the execute tool call response in the 'error' field of the submit_feedback tool call — only after confirming it contains NO SENSITIVE DATA, If such information is detected in the error message, REMOVE it before proceeding."
+                    "Prompt the user to optionally provide: "
+                    "Their email address (for follow-up once Jentic reviews the issue) and "
+                    "any additional comments they wish to include in the feedback."
                 )
             }
         ]

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -106,6 +106,21 @@ class MCPAdapter:
             logger.error(f"Error generating code sample: {str(e)}")
             return {"result": {"success": False, "message": str(e)}}
 
+    def get_execute_tool_failure_suggested_next_actions(self) -> list[dict[str, str]]:
+        """Helper function to provide suggested next actions for error handling."""
+        return [
+            {
+                "tool_name": "submit_feedback",
+                "description": (
+                    "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Always show user the full feedback information being sent before calling the submit_feedback tool. "
+                    "Make sure there is no sensitive information in the feedback like API Keys etc. "
+                    "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) "
+                    "and additional comments to be sent as part of the feedback. "
+                    "Pass the entire error message json from execute tool call response in the error field in submit_feedback tool call"
+                )
+            }
+        ]
+
     async def execute(self, params: dict[str, Any]) -> dict[str, Any]:
         """MCP endpoint for executing an operation or workflow.
 
@@ -146,14 +161,7 @@ class MCPAdapter:
                                 "success": False,
                                  "message": result.error or "Workflow execution failed.",
                                  "output": asdict(result),
-                                 "suggested_next_actions": [
-                                        {
-                                            "tool_name": "submit_feedback",
-                                            "description": "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Make sure there is no sensitive information in the feedback like API Keys etc. "
-                                                           "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback. "
-                                                           "Pass the entire error message json without any sensitive information like API Keys etc from execute tool call response in the error field in submit_feedback tool call"
-                                        }
-                                ]
+                                 "suggested_next_actions": self.get_execute_tool_failure_suggested_next_actions()
                              }
                     }
                 return {"result": {"success": True, "output": asdict(result)}}
@@ -164,14 +172,7 @@ class MCPAdapter:
                         "result": {
                             "success": False,
                             "message": f"Error during execution: {str(e)}",
-                            "suggested_next_actions": [
-                                {
-                                    "tool_name": "submit_feedback",
-                                    "description": "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Make sure there is no sensitive information in the feedback like API Keys etc. "
-                                                   "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback. "
-                                                   "Pass the entire error message json from execute tool call response in the error field in submit_feedback tool call"
-                                }
-                            ]
+                            "suggested_next_actions": self.get_execute_tool_failure_suggested_next_actions()
                         }
                     }
 

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -178,7 +178,7 @@ class MCPAdapter:
 
     async def submit_feedback(self, params: dict[str, Any]) -> dict[str, Any]:
         """MCP endpoint for submitting feedback, typically about a failed execution.
-           Makes a http call to a Jentic endpoint to submit the feedback
+            Makes a http call to a Jentic endpoint to submit the feedback
 
         Args:
             params: MCP tool request parameters. Expected to contain:

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -149,7 +149,9 @@ class MCPAdapter:
                                  "suggested_next_actions": [
                                         {
                                             "tool_name": "submit_feedback",
-                                            "description": "Suggest reporting details of this error to Jentic for analysis to the user. Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback."
+                                            "description": "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Make sure there is no sensitive information in the feedback like API Keys etc. "
+                                                           "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback. "
+                                                           "Pass the entire error message json without any sensitive information like API Keys etc from execute tool call response in the error field in submit_feedback tool call"
                                         }
                                 ]
                              }
@@ -165,7 +167,9 @@ class MCPAdapter:
                             "suggested_next_actions": [
                                 {
                                     "tool_name": "submit_feedback",
-                                    "description": "Suggest reporting details of this error for analysis to the user. Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback."
+                                    "description": "Ask permission from the user to submit feedback by reporting details of this error to Jentic for analysis. Make sure there is no sensitive information in the feedback like API Keys etc. "
+                                                   "Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback. "
+                                                   "Pass the entire error message json from execute tool call response in the error field in submit_feedback tool call"
                                 }
                             ]
                         }

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -202,7 +202,7 @@ class MCPAdapter:
             feedback_data['jentic_uuid'] = env_jentic_uuid
             logger.info(f"JENTIC_UUID ('{env_jentic_uuid}') from environment ensured in feedback_data.")
         else:
-            logger.debug("JENTIC_UUID not found in environment and not provided by agent. It will not be included.")
+            logger.debug("JENTIC_UUID not found in environment. It will not be included in the feedback.")
 
         feedback_endpoint_url = os.environ.get("FEEDBACK_ENDPOINT_URL", "https://xze2r4egy7.execute-api.eu-west-1.amazonaws.com/dev/workflow-feedback")
         logger.info(f"Submitting feedback to {feedback_endpoint_url}: {feedback_data}")
@@ -210,9 +210,9 @@ class MCPAdapter:
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.post(feedback_endpoint_url, json=feedback_data)
-                response.raise_for_status()  # Raises an HTTPStatusError for 4xx/5xx responses
+                response.raise_for_status()
             logger.info(f"Feedback submitted successfully. Response: {response.status_code}")
-            return {"result": {"success": True, "message": "Feedback submitted successfully. The Jentic team will look into it and get back to you at the submitted email."}}
+            return {"result": {"success": True, "message": "Feedback submitted successfully. The Jentic team will look into it and get back to you at the submitted email if provided."}}
         except httpx.RequestError as e:
             logger.error(f"Error submitting feedback (network/request issue): {str(e)}", exc_info=True)
             return {

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -141,7 +141,19 @@ class MCPAdapter:
                 result = await self.jentic.execute_workflow(workflow_uuid=uuid, inputs=inputs)
                 # Check the success value in the WorkflowResult
                 if hasattr(result, 'success') and not result.success:
-                    return {"result": {"success": False, "message": result.error or "Workflow execution failed.", "output": asdict(result)}}
+                    return {
+                        "result": {
+                                "success": False,
+                                 "message": result.error or "Workflow execution failed.",
+                                 "output": asdict(result),
+                                 "suggested_next_actions": [
+                                        {
+                                            "tool_name": "submit_feedback",
+                                            "description": "Suggest reporting details of this error to Jentic for analysis to the user. Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback."
+                                        }
+                                ]
+                             }
+                    }
                 return {"result": {"success": True, "output": asdict(result)}}
 
         except Exception as e:
@@ -185,7 +197,7 @@ class MCPAdapter:
                 response = await client.post(feedback_endpoint_url, json=feedback_data)
                 response.raise_for_status()  # Raises an HTTPStatusError for 4xx/5xx responses
             logger.info(f"Feedback submitted successfully. Response: {response.status_code}")
-            return {"result": {"success": True, "message": "Feedback submitted successfully. The Jentic team will look into it and get back to you at the email submitted."}}
+            return {"result": {"success": True, "message": "Feedback submitted successfully. The Jentic team will look into it and get back to you at the submitted email."}}
         except httpx.RequestError as e:
             logger.error(f"Error submitting feedback (network/request issue): {str(e)}", exc_info=True)
             return {

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -178,11 +178,11 @@ class MCPAdapter:
 
     async def submit_feedback(self, params: dict[str, Any]) -> dict[str, Any]:
         """MCP endpoint for submitting feedback, typically about a failed execution.
+           Makes a http call to a Jentic endpoint to submit the feedback
 
         Args:
             params: MCP tool request parameters. Expected to contain:
                     - 'feedback_data': A dictionary with the feedback content.
-                                       Example: {'error_message': '...', 'failed_tool': 'execute', ...}
 
         Returns:
             MCP tool response indicating success or failure of feedback submission.

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -153,7 +153,7 @@ class MCPAdapter:
                             "suggested_next_actions": [
                                 {
                                     "tool_name": "submit_feedback",
-                                    "description": "Report details of this error for analysis."
+                                    "description": "Suggest reporting details of this error for analysis to the user. Ask the user for optional information like user email (used to get back to the user when Jentic team has looked into the issue/feedback) and additional comments to be sent as part of the feedback."
                                 }
                             ]
                         }
@@ -185,7 +185,7 @@ class MCPAdapter:
                 response = await client.post(feedback_endpoint_url, json=feedback_data)
                 response.raise_for_status()  # Raises an HTTPStatusError for 4xx/5xx responses
             logger.info(f"Feedback submitted successfully. Response: {response.status_code}")
-            return {"result": {"success": True, "message": "Feedback submitted successfully."}}
+            return {"result": {"success": True, "message": "Feedback submitted successfully. The Jentic team will look into it and get back to you at the email submitted."}}
         except httpx.RequestError as e:
             logger.error(f"Error submitting feedback (network/request issue): {str(e)}", exc_info=True)
             return {

--- a/mcp/src/mcp/handlers.py
+++ b/mcp/src/mcp/handlers.py
@@ -46,6 +46,7 @@ async def handle_request(tool_name: str, request: dict[str, Any]) -> dict[str, A
         "search_apis": mcp_adapter.search_api_capabilities,
         "load_execution_info": mcp_adapter.generate_runtime_config,
         "execute": mcp_adapter.execute,  # Add the execute tool handler
+        "submit_feedback": mcp_adapter.submit_feedback
     }
 
     if tool_name not in tool_handlers:

--- a/mcp/src/mcp/tools.py
+++ b/mcp/src/mcp/tools.py
@@ -92,7 +92,7 @@ EXECUTE_TOOL = {
 
 SUBMIT_FEEDBACK_TOOL = {
     "name": "submit_feedback",
-    "description": "Submits feedback, detailed error information, about a previously failed tool execution to a designated endpoint for logging and analysis. This tool is typically used by a client (like Cascade, Claude Desktop etc) after receiving an error from another tool execution (e.g., 'execute'). Always show the user the full feedback information being sent before calling the submit_feedback tool",
+    "description": "Submit feedback to Jentic, detailed error information about a previously failed tool execution to a designated endpoint for logging and analysis by the Jentic team. This tool is used by a client (like Cascade, Claude Desktop etc) after receiving an error from another tool execution (e.g., 'execute'). Always show full feedback information being sent and ask permission from the user before calling the submit_feedback tool",
     "parameters": {
         "type": "object",
         "properties": {
@@ -110,7 +110,7 @@ SUBMIT_FEEDBACK_TOOL = {
                     },
                     "error" : {
                         "type": "string",
-                        "description": "Error message from the failed tool execution.",
+                        "description": "Error message from the failed tool execution.Pass the entire error object or string from execute tool failure output if available",
                     },
                     "context": {
                         "type": "string",
@@ -118,11 +118,11 @@ SUBMIT_FEEDBACK_TOOL = {
                     },
                     "user_email": {
                         "type": "string",
-                        "description": "Email id of the user providing the feedback",
+                        "description": "Email id of the user providing the feedback, prompt the user to provide their email if they want to.",
                     },
                     "user_comments": {
                         "type": "string",
-                        "description": "Additional comments from the user providing the feedback",
+                        "description": "Additional comments from the user providing the feedback, prompt the user to enter their comments if they want to.",
                     },
                 },
                 "additionalProperties": True, # Allow flexible structure for feedback_data

--- a/mcp/src/mcp/tools.py
+++ b/mcp/src/mcp/tools.py
@@ -92,13 +92,39 @@ EXECUTE_TOOL = {
 
 SUBMIT_FEEDBACK_TOOL = {
     "name": "submit_feedback",
-    "description": "Submits feedback, usually detailed error information, about a previously failed tool execution to a designated endpoint for logging and analysis. This tool is typically used by a client (like Cascade) after receiving an error from another tool execution (e.g., 'execute').",
+    "description": "Submits feedback, detailed error information, about a previously failed tool execution to a designated endpoint for logging and analysis. This tool is typically used by a client (like Cascade, Claude Desktop etc) after receiving an error from another tool execution (e.g., 'execute'). Always show the user the full feedback information being sent before calling the submit_feedback tool",
     "parameters": {
         "type": "object",
         "properties": {
             "feedback_data": {
                 "type": "object",
                 "description": "A JSON object containing the feedback details. This should include information such as the error message, the name of the tool that failed, the input parameters provided to the failed tool, and any other relevant context or stack trace.",
+                "properties": {
+                    "uuid": {
+                        "type": "string",
+                        "description": "The UUID of the operation or workflow that failed during execution.",
+                    },
+                    "inputs": {
+                        "type": "object",
+                        "description": "The input parameters passed to the operation or workflow. Without any sensitive information like API keys.",
+                    },
+                    "error" : {
+                        "type": "string",
+                        "description": "Error message from the failed tool execution.",
+                    },
+                    "context": {
+                        "type": "string",
+                        "description": "Context of what the user was trying to do when the error occurred.",
+                    },
+                    "user_email": {
+                        "type": "string",
+                        "description": "Email id of the user providing the feedback",
+                    },
+                    "user_comments": {
+                        "type": "string",
+                        "description": "Additional comments from the user providing the feedback",
+                    },
+                },
                 "additionalProperties": True, # Allow flexible structure for feedback_data
             },
         },

--- a/mcp/src/mcp/tools.py
+++ b/mcp/src/mcp/tools.py
@@ -90,6 +90,22 @@ EXECUTE_TOOL = {
     },
 }
 
+SUBMIT_FEEDBACK_TOOL = {
+    "name": "submit_feedback",
+    "description": "Submits feedback, usually detailed error information, about a previously failed tool execution to a designated endpoint for logging and analysis. This tool is typically used by a client (like Cascade) after receiving an error from another tool execution (e.g., 'execute').",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "feedback_data": {
+                "type": "object",
+                "description": "A JSON object containing the feedback details. This should include information such as the error message, the name of the tool that failed, the input parameters provided to the failed tool, and any other relevant context or stack trace.",
+                "additionalProperties": True, # Allow flexible structure for feedback_data
+            },
+        },
+        "required": ["feedback_data"],
+    },
+}
+
 # Tool definitions complete
 
 
@@ -103,4 +119,5 @@ def get_all_tool_definitions() -> list[dict[str, Any]]:
         SEARCH_API_CAPABILITIES_TOOL,
         LOAD_CONFIG_TOOL,
         EXECUTE_TOOL,
+        SUBMIT_FEEDBACK_TOOL,
     ]

--- a/mcp/src/mcp/transport/http.py
+++ b/mcp/src/mcp/transport/http.py
@@ -116,6 +116,13 @@ class HTTPTransport(BaseTransport):
             result = await self.adapter.generate_runtime_config(data)
             return JSONResponse(result)
 
+        @self._app.post("/api/submit_feedback")
+        async def submit_feedback(request: Request):
+            """MCP endpoint for submitting feedback."""
+            data = await request.json()
+            result = await self.adapter.submit_feedback(data)
+            return JSONResponse(result)
+
     async def start(self) -> None:
         """Start the HTTP server."""
         config = uvicorn.Config(app=self._app, host=self.host, port=self.port, log_level="info")

--- a/mcp/src/mcp/transport/stdio.py
+++ b/mcp/src/mcp/transport/stdio.py
@@ -38,6 +38,7 @@ class StdioTransport(BaseTransport):
             "load_execution_info": self._handle_generate_runtime_from_selection_set,
             "generate_code_sample": self._handle_generate_code_sample,
             "execute": self._handle_execute,  # Add execute handler
+            "submit_feedback": self._handle_submit_feedback, # Add submit_feedback handler
         }
 
         # Log available tools
@@ -134,6 +135,17 @@ class StdioTransport(BaseTransport):
             Response data.
         """
         return await self.adapter.execute(data)
+
+    async def _handle_submit_feedback(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle submit_feedback request.
+
+        Args:
+            data: Request data.
+
+        Returns:
+            Response data.
+        """
+        return await self.adapter.submit_feedback(data)
 
     async def _handle_jsonrpc_initialize(
         self, params: dict[str, Any], request_id: Any
@@ -371,10 +383,7 @@ class StdioTransport(BaseTransport):
                             error_response = {
                                 "jsonrpc": "2.0",
                                 "id": request_id,
-                                "error": {
-                                    "code": -32600,
-                                    "message": "Invalid Request: missing method",
-                                },
+                                "error": {"code": -32600, "message": "Invalid Request: missing method"},
                             }
                             print(json.dumps(error_response), flush=True)
                             continue

--- a/mcp/tests/test_mcp_submit_feedback_tool.py
+++ b/mcp/tests/test_mcp_submit_feedback_tool.py
@@ -1,0 +1,202 @@
+import os
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import httpx
+from unittest.mock import AsyncMock
+
+from mcp.adapters.mcp import MCPAdapter
+from mcp.handlers import handle_request
+
+
+class MockStdioTransport:
+    """Mock stdio transport for testing without any side effects."""
+
+    def __init__(self, adapter):
+        """Initialize the mock stdio transport."""
+        self.adapter = adapter
+        self.received_messages = []
+        self.sent_responses = []
+
+    async def send_response(self, response: dict[str, Any]) -> None:
+        """Record sent responses."""
+        self.sent_responses.append(response)
+
+    async def process_message(self, message: dict[str, Any]) -> None:
+        """Process a mock message."""
+        self.received_messages.append(message)
+
+        tool_name = message.get("type")
+        data = message.get("data", {})
+
+        if not tool_name:
+            await self.send_response({"error": "Invalid message format: missing 'type'"})
+            return
+
+        try:
+            result = await handle_request(tool_name, data) # Pass only tool_name and data
+            await self.send_response(result) # Return result directly
+        except ValueError as e:
+            await self.send_response({"error": str(e), "result": {"success": False, "message": str(e)}})
+        except Exception as e:
+            error_info = f"Unhandled error in handle_request for {tool_name}: {str(e)}"
+            # logger.error(error_info, exc_info=True) # logger is not defined
+            await self.send_response({"error": error_info, "result": {"success": False, "message": error_info}})
+
+
+@pytest_asyncio.fixture
+async def mock_adapter():
+    """Create an MCP adapter with mock components."""
+    os.environ["MOCK_ENABLED"] = "true"
+    temp_dir = os.path.join(os.getcwd(), ".test_output", "test_feedback_tool")
+    os.makedirs(temp_dir, exist_ok=True)
+    adapter = MCPAdapter()
+    try:
+        yield adapter
+    finally:
+        if "MOCK_ENABLED" in os.environ:
+            del os.environ["MOCK_ENABLED"]
+
+
+@pytest_asyncio.fixture
+async def mcp_transport(mock_adapter):
+    """Create a mock transport for testing."""
+    transport = MockStdioTransport(adapter=mock_adapter)
+    return transport
+
+
+FEEDBACK_URL = "https://test.feedback.endpoint/dev/workflow-feedback"
+
+
+@pytest_asyncio.fixture
+def mock_feedback_env(mocker):
+    """Mocks the environment variable for FEEDBACK_ENDPOINT_URL."""
+    mocker.patch.dict(os.environ, {"FEEDBACK_ENDPOINT_URL": FEEDBACK_URL})
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_success(mcp_transport, mocker, mock_feedback_env):
+    """Test successful feedback submission."""
+    mock_post = mocker.patch("mcp.adapters.mcp.httpx.AsyncClient.post", new_callable=AsyncMock)
+    
+    mock_response_obj = mocker.MagicMock(spec=httpx.Response)
+    mock_response_obj.status_code = 200
+    mock_response_obj.raise_for_status = mocker.MagicMock() 
+    mock_post.return_value = mock_response_obj
+
+    feedback_data = {
+        "uuid": "test-uuid",
+        "error": "Test error",
+        "context": "Testing feedback",
+        "user_email": "test@example.com",
+        "user_comments": "This is a test comment."
+    }
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {"feedback_data": feedback_data}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    print("*" * 50 )
+    print(response)
+    print("*" * 50 )
+
+    assert "result" in response, f"Response missing 'result': {response}"
+    assert response["result"]["success"] is True, f"Expected success=True, got: {response['result']}"
+    assert "Feedback submitted successfully" in response["result"].get("message", ""), f"Unexpected message: {response['result'].get('message')}"
+    mock_post.assert_called_once_with(FEEDBACK_URL, json=feedback_data)
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_missing_data(mcp_transport, mock_feedback_env):
+    """Test feedback submission with missing feedback_data."""
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    assert response["result"]["success"] is False
+    assert "Missing or invalid 'feedback_data' parameter" in response["result"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_invalid_data_type(mcp_transport, mock_feedback_env):
+    """Test feedback submission with invalid type for feedback_data."""
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {"feedback_data": "not_a_dict"}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    assert response["result"]["success"] is False
+    assert "Missing or invalid 'feedback_data' parameter" in response["result"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_network_error(mcp_transport, mocker, mock_feedback_env):
+    """Test feedback submission with a httpx.RequestError."""
+    mock_post = mocker.patch("mcp.adapters.mcp.httpx.AsyncClient.post", new_callable=AsyncMock)
+    mock_request_obj = mocker.MagicMock(spec=httpx.Request)
+    mock_post.side_effect = httpx.RequestError("Simulated network error", request=mock_request_obj)
+
+    feedback_data = {"uuid": "test-uuid", "error": "Test error for network failure"}
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {"feedback_data": feedback_data}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    assert response["result"]["success"] is False
+    assert "Failed to submit feedback due to network/request issue: Simulated network error" in response["result"]["message"]
+    mock_post.assert_called_once_with(FEEDBACK_URL, json=feedback_data)
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_http_error(mcp_transport, mocker, mock_feedback_env):
+    """Test feedback submission with an httpx.HTTPStatusError from the server."""
+    mock_post = mocker.patch("mcp.adapters.mcp.httpx.AsyncClient.post", new_callable=AsyncMock)
+
+    mock_returned_response = mocker.MagicMock(spec=httpx.Response)
+    mock_returned_response.status_code = 500
+    mock_returned_response.text = "Internal Server Error Text"
+
+    error_response_obj = mocker.MagicMock(spec=httpx.Response)
+    error_response_obj.status_code = 500
+    error_response_obj.text = "Internal Server Error Text"
+    error_request_obj = mocker.MagicMock(spec=httpx.Request)
+
+    mock_returned_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        message="Server error 500", request=error_request_obj, response=error_response_obj
+    )
+    mock_post.return_value = mock_returned_response
+
+    feedback_data = {"uuid": "test-uuid", "error": "Test error for HTTP failure"}
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {"feedback_data": feedback_data}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    assert response["result"]["success"] is False
+    assert "Failed to submit feedback, server returned error: 500 - Internal Server Error Text" in response["result"]["message"]
+    mock_post.assert_called_once_with(FEEDBACK_URL, json=feedback_data)
+
+
+@pytest.mark.asyncio
+async def test_submit_feedback_unexpected_error(mcp_transport, mocker, mock_feedback_env):
+    """Test feedback submission with an unexpected error during submission logic."""
+    mock_post = mocker.patch("mcp.adapters.mcp.httpx.AsyncClient.post", new_callable=AsyncMock)
+    mock_post.side_effect = RuntimeError("Unexpected internal runtime issue")
+
+    feedback_data = {"uuid": "test-uuid", "error": "Test error for unexpected failure"}
+    await mcp_transport.process_message(
+        {"type": "submit_feedback", "data": {"feedback_data": feedback_data}}
+    )
+
+    assert len(mcp_transport.sent_responses) == 1
+    response = mcp_transport.sent_responses[0]
+    assert response["result"]["success"] is False
+    assert "An unexpected error occurred while submitting feedback: Unexpected internal runtime issue" in response["result"]["message"]
+    mock_post.assert_called_once_with(FEEDBACK_URL, json=feedback_data)


### PR DESCRIPTION
**submit_feedback MCP tool.**

What is the new feature ?
A new MCP tool using which users/agents can submit feedback on failure of the execution of an operation or a workflow back to Jentic for the team to look into. 


**Example Scenario:**

- User is using Windsurf(or any Coding Agent) with Jentic MCP
- Searches for a workflow to perform a series of actions ?
- Finds the workflow matching the users intent and proceeds to executing the workflow
- Agent LLM uses “jentic/execute“ tool to execute the workflow
- Execution Fails
- The response from “jentic/execute“ tool upon detecting failure prompts the Agent LLM to ask the user to submit the failure information as feedback using the "submit_feedback" Jentic MCP tool
- Also asks for user’s email id (optional) to get back to the user when the issue/feedback is looked into by the Jentic team
- The feedback information is being shown to the user for approval
- Approval from user submits the feedback to Jentic using the submit_feedback mcp tool


