### PR TITLE
fix: jentic dependency updated to 0.7.6 from 0.7.5 for jentic-mcp

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.5"
+    "jentic >=0.7.6"
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Updating the jentic dependency from 0.7.5 to 0.7.6 for jentic-mcp.
0.7.6 is the latest deployed version https://pypi.org/project/jentic/ 