### PR TITLE
chore: bump python sdk version to 0.7.9

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.7.8"
+version = "0.7.9"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},


### PR DESCRIPTION
Bump Python SDK patch version to 0.7.9