### PR TITLE
chore: update jentic dependency to 0.7.9

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.8"
+    "jentic >=0.7.9"
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Update the jentic dependency in MCP to version 0.7.9 to stay in sync with the Python SDK updates.