### PR TITLE
feat: add server variable support

### DIFF
--- a/python/pdm.lock
+++ b/python/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c7713fc954cfb61cc3830a159a5e6444e5ccb5f6accd2c57639d6ea252ebf577"
+content_hash = "sha256:092a1022a5b650d78d88ca8e035268adb3146fac0db39d9cb2b9cbf6b90e36fc"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -343,7 +343,7 @@ files = [
 
 [[package]]
 name = "oak-runner"
-version = "0.8.6"
+version = "0.8.7"
 requires_python = ">=3.10"
 summary = "Execution libraries and test tools for Arazzo workflows and Open API operations"
 groups = ["default"]
@@ -353,10 +353,6 @@ dependencies = [
     "pydantic>=2.0.0",
     "pyyaml>=6.0",
     "requests>=2.28.0",
-]
-files = [
-    {file = "oak_runner-0.8.6-py3-none-any.whl", hash = "sha256:13d582ff77071afad6a0e1b365400807c38cdde2cbbc85df0cc0c87975128c3f"},
-    {file = "oak_runner-0.8.6.tar.gz", hash = "sha256:403ef2a9bf6208c5846eb276172e8366ecaa0f573de3dcffad8019d4013b5f2f"},
 ]
 
 [[package]]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonpath-ng>=1.5.0",
     "httpx>=0.28.1",
-    "oak-runner>=0.8.6"
+    "oak-runner>=0.8.7"
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/python/src/jentic/agent_runtime/config.py
+++ b/python/src/jentic/agent_runtime/config.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from oak_runner.auth.auth_processor import AuthProcessor
 from oak_runner.auth.models import SecurityOption
 from oak_runner.extractor.openapi_extractor import extract_operation_io
+from oak_runner import OAKRunner
 
 from jentic.api.api_hub import JenticAPIClient
 from jentic.models import GetFilesResponse
@@ -184,7 +185,7 @@ class JenticConfig:
             )
 
         # Step 5: Process authentication requirements
-        env_mappings = JenticConfig._process_auth(all_openapi_specs, all_arazzo_specs)
+        env_mappings = OAKRunner.generate_env_mappings(arazzo_docs=all_arazzo_specs, source_descriptions=all_openapi_specs)
 
         # Step 6: Compose final config
         final_config = {


### PR DESCRIPTION
`oak-runner 0.8.7` Adds support for [server variables](https://learn.openapis.org/specification/servers.html#server-variables). This PR includes this change in the Jentic Python SDK. 