### PR TITLE
chore: bump version to 0.7.10

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.7.9"
+version = "0.7.10"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},


### PR DESCRIPTION
## Summary
- Bump jentic Python package version from 0.7.9 to 0.7.10