### PR TITLE
JENTICPROD-227 Feat - Tool name deduplication

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.7.10"
+version = "0.7.11"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic"
-version = "0.7.9"
+version = "0.7.10"
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},

--- a/python/src/jentic/agent_runtime/tool_specs.py
+++ b/python/src/jentic/agent_runtime/tool_specs.py
@@ -48,6 +48,7 @@ class LLMToolSpecManager:
             "openai": None,
             "anthropic": None,
         }
+        # Vendor prefixes are added when api_name is present
 
     def load_workflows(self, workflows: dict[str, Any]) -> None:
         """Load workflow specifications into the manager.
@@ -184,9 +185,15 @@ class LLMToolSpecManager:
         """
         parameters = self._extract_parameters(workflow)
         required = self._extract_required_parameters(workflow)
-
+        
+        name = workflow_id
+        if "api_name" in workflow:
+            # Only add prefix if api_name is explicitly provided
+            vendor = workflow["api_name"]
+            name = f"{vendor}-{workflow_id}"
+        
         return {
-            "name": workflow_id,
+            "name": name,
             "description": workflow.get("description", f"Execute the {workflow_id} workflow"),
             "parameters": {
                 "type": "object",
@@ -214,9 +221,15 @@ class LLMToolSpecManager:
             or operation.get("description")
             or f"Execute {operation.get('method', 'HTTP')} request to {operation.get('path', 'endpoint')}"
         )
+        
+        name = tool_name
+        if "api_name" in operation:
+            # Only add prefix if api_name is explicitly provided
+            vendor = operation["api_name"]
+            name = f"{vendor}-{tool_name}"
 
         return {
-            "name": tool_name,
+            "name": name,
             "description": description,
             "parameters": {
                 "type": "object",
@@ -260,9 +273,15 @@ class LLMToolSpecManager:
         """
         parameters = self._extract_parameters(workflow)
         required = self._extract_required_parameters(workflow)
+        
+        name = workflow_id
+        if "api_name" in workflow:
+            # Only add prefix if api_name is explicitly provided
+            vendor = workflow["api_name"]
+            name = f"{vendor}-{workflow_id}"
 
         return {
-            "name": workflow_id,
+            "name": name,
             "description": workflow.get("description", f"Execute the {workflow_id} workflow"),
             "input_schema": {
                 "$schema": "http://json-schema.org/draft-07/schema#",
@@ -286,8 +305,14 @@ class LLMToolSpecManager:
             Anthropic tool schema.
         """
         tool_name_base = self._generate_operation_tool_name(operation)
+        
         # Convert to Anthropic's preferred kebab-case
         tool_name = tool_name_base.replace("_", "-").lower()
+        
+        # Only add prefix if api_name is explicitly provided
+        if "api_name" in operation:
+            vendor = operation["api_name"]
+            tool_name = f"{vendor}-{tool_name}"
 
         parameters, required = self._extract_operation_parameters(operation)
         description = (

--- a/python/tests/agent_runtime/test_agent_runtime.py
+++ b/python/tests/agent_runtime/test_agent_runtime.py
@@ -19,6 +19,7 @@ class TestLLMToolSpecManager:
         return {
             "workflowId": "testWorkflow",
             "description": "A test workflow",
+            "api_name": "Discord",  # Vendor name for the workflow
             "inputs": {
                 "properties": {
                     "query": {
@@ -61,7 +62,7 @@ class TestLLMToolSpecManager:
         # Verify workflows are loaded (implementation-specific, testing through get_tool_specs)
         specs = manager.get_tool_specs("openai")
         assert len(specs["tools"]) == 1
-        assert specs["tools"][0]["function"]["name"] == "testWorkflow"
+        assert specs["tools"][0]["function"]["name"] == "Discord-testWorkflow"
 
     def test_extract_parameters(self, sample_workflow):
         """Test parameter extraction from workflows."""
@@ -102,7 +103,7 @@ class TestLLMToolSpecManager:
 
         tool = specs["tools"][0]
         assert tool["type"] == "function"
-        assert tool["function"]["name"] == "testWorkflow"
+        assert tool["function"]["name"] == "Discord-testWorkflow"
         assert tool["function"]["description"] == "A test workflow"
         assert tool["function"]["parameters"]["type"] == "object"
         assert "query" in tool["function"]["parameters"]["properties"]
@@ -119,7 +120,7 @@ class TestLLMToolSpecManager:
         assert len(specs["tools"]) == 1
 
         tool = specs["tools"][0]
-        assert tool["name"] == "testWorkflow"
+        assert tool["name"] == "Discord-testWorkflow"
         assert tool["description"] == "A test workflow"
         assert tool["input_schema"]["type"] == "object"
         assert "query" in tool["input_schema"]["properties"]
@@ -151,3 +152,17 @@ class TestLLMToolSpecManager:
             openai_specs["tools"][0]["function"]["description"]
             == claude_specs["tools"][0]["description"]
         )
+
+    def test_vendor_prefix_feature(self, sample_workflow):
+        """Test that vendor prefixes are correctly added to tool names when enabled."""
+        manager = create_llm_tool_manager()
+        # Ensure vendor prefixes are enabled (default is True)
+        manager.load_workflows({"testWorkflow": sample_workflow})
+        
+        # Test OpenAI format
+        openai_specs = manager.get_tool_specs("openai")
+        assert openai_specs["tools"][0]["function"]["name"] == "Discord-testWorkflow"
+        
+        # Test Anthropic format
+        anthropic_specs = manager.get_tool_specs("anthropic")
+        assert anthropic_specs["tools"][0]["name"] == "Discord-testWorkflow"

--- a/python/tests/agent_runtime/test_parameter_sanitization.py
+++ b/python/tests/agent_runtime/test_parameter_sanitization.py
@@ -1,0 +1,141 @@
+"""Tests for parameter name sanitization in the LLM tool specification manager."""
+
+import pytest
+
+from jentic.agent_runtime.tool_specs import (
+    LLMToolSpecManager,
+    create_llm_tool_manager,
+)
+
+
+def test_anthropic_parameter_sanitization():
+    """Test that parameter names are properly sanitized for Anthropic schema."""
+    # Operation with problematic keys (dots, spaces, etc.)
+    sample_operation = {
+        "method": "GET",
+        "path": "/users",
+        "inputs": {
+            "properties": {
+                "user.id": {"type": "string"},
+                "name.first": {"type": "string"},
+                "complex-key.with space": {"type": "string"},
+            },
+            "required": ["user.id"],
+        },
+    }
+
+    manager = create_llm_tool_manager()
+    manager.load_operations({"test-op-uuid": sample_operation})
+    
+    # Get anthropic tool specs
+    specs = manager.get_tool_specs("anthropic")
+    tool = specs["tools"][0]
+    properties = tool["input_schema"]["properties"]
+    required = tool["input_schema"]["required"]
+    
+    # Verify keys were sanitized correctly
+    assert "user_id" in properties
+    assert "name_first" in properties
+    assert "complex-key_with_space" in properties
+    assert "user.id" not in properties
+    
+    # Verify required list was also sanitized
+    assert "user_id" in required
+    
+    # Verify mapping is created for restoration
+    mapping = manager._parameter_mappings[tool["name"]]
+    assert mapping["user_id"] == "user.id"
+    
+    # Test parameter restoration
+    test_inputs = {"user_id": "123", "name_first": "John"}
+    restored = manager.restore_input_parameter_names(tool["name"], test_inputs)
+    assert "user.id" in restored
+    assert restored["user.id"] == "123"
+
+
+def test_edge_case_parameter_sanitization():
+    """Test edge cases for parameter name sanitization."""
+    sample_operation = {
+        "method": "GET",
+        "path": "/edge-cases",
+        "inputs": {
+            "properties": {
+                "": {"type": "string"},  # Empty string
+                "a" * 100: {"type": "string"},  # Very long key
+                "!@#$%^&*()": {"type": "string"},  # Only special chars
+                " leading-trailing ": {"type": "string"},  # Leading/trailing spaces
+                "..multiple...dots..": {"type": "string"},  # Multiple dots
+            },
+            "required": ["!@#$%^&*()"],
+        },
+    }
+
+    manager = create_llm_tool_manager()
+    manager.load_operations({"edge-case-uuid": sample_operation})
+    
+    # Get anthropic tool specs
+    specs = manager.get_tool_specs("anthropic")
+    tool = specs["tools"][0]
+    properties = tool["input_schema"]["properties"]
+    required = tool["input_schema"]["required"]
+    
+    # Verify edge cases were handled correctly
+    assert "param" in properties  # Empty string or special chars should get fallback name
+    assert len(list(filter(lambda k: k.startswith("a" * 60), properties.keys()))) == 1  # Truncated
+    assert "leading-trailing" in properties  # Spaces removed
+    assert "multiple_dots" in properties  # Multiple dots/underscores consolidated
+    
+    # Check mappings
+    mapping = manager._parameter_mappings[tool["name"]]
+    assert "" in mapping.values() or "!@#$%^&*()" in mapping.values()  # Either empty or special chars map to param
+    
+    # Verify required list was properly sanitized
+    assert "param" in required  # Special chars in required list mapped to param
+    
+    # Test restoration with edge cases
+    edge_inputs = {
+        "param": "empty_or_special",
+        list(filter(lambda k: k.startswith("a" * 60), properties.keys()))[0]: "truncated"
+    }
+    
+    restored = manager.restore_input_parameter_names(tool["name"], edge_inputs)
+    # Check that either empty string or special chars are restored from "param"
+    assert "" in restored or "!@#$%^&*()" in restored  
+    long_key = list(filter(lambda k: len(k) >= 100, mapping.values()))
+    assert len(long_key) == 1  # Should have one long key in mappings
+    assert long_key[0] in restored  # Long key restored
+
+
+def test_valid_parameter_names_unchanged():
+    """Test that valid parameter names are not modified."""
+    sample_operation = {
+        "method": "GET",
+        "path": "/users",
+        "inputs": {
+            "properties": {
+                "user_id": {"type": "string"},
+                "name": {"type": "string"},
+                "page-number": {"type": "integer"},
+            },
+            "required": ["user_id"],
+        },
+    }
+
+    manager = create_llm_tool_manager()
+    manager.load_operations({"op-uuid": sample_operation})
+    
+    # Get anthropic tool specs
+    specs = manager.get_tool_specs("anthropic")
+    tool = specs["tools"][0]
+    properties = tool["input_schema"]["properties"]
+    
+    # Verify valid keys remain unchanged
+    assert "user_id" in properties
+    assert "name" in properties
+    assert "page-number" in properties
+    
+    # Verify mapping doesn't contain entries for valid keys
+    mapping = manager._parameter_mappings.get(tool["name"], {})
+    assert "user_id" not in mapping
+    assert "name" not in mapping
+    assert "page-number" not in mapping


### PR DESCRIPTION
- Add vendor prefixing to tool names (e.g., 'Discord-sendMessage') when api_name is explicitly provided
- Update both OpenAI and Anthropic format generators to use vendor prefixes
- Add comprehensive tests to verify prefixing