### PR TITLE
fix(mcp): [JENTICPROD-351] improve API name propagation and refactor name extraction [Part 2 - MCP update]

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.4"
+version = "0.6.5"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.10",
+    "jentic >=0.7.12",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -62,25 +62,27 @@ class MCPAdapter:
         Returns:
             MCP tool response.
         """
-        workflow_uuids = request.get("workflow_uuids")
-        operation_uuids = request.get("operation_uuids")
+        # Get the workflow and operation UUIDs from the request
+        workflow_uuids = request.get("workflow_uuids", [])
+        if isinstance(workflow_uuids, str):
+            workflow_uuids = [workflow_uuids]
+        operation_uuids = request.get("operation_uuids", [])
+        if isinstance(operation_uuids, str):
+            operation_uuids = [operation_uuids]
+        
+        # Get the API name or use empty string as default
+        api_name = request.get("api_name", "")
 
-        # Log the project directory for debugging
         logger = logging.getLogger(__name__)
-        logger.info(
-            f"Generating config with workflow_uuids: {workflow_uuids}, operation_uuids: {operation_uuids}"
+        logger.debug(
+            f"Generating config with workflow_uuids: {workflow_uuids}, operation_uuids: {operation_uuids}, api_name: {api_name}"
         )
 
         try:
             # Generate configuration from the selection set
             result = await self.jentic.load_execution_info(
-                workflow_uuids=workflow_uuids, operation_uuids=operation_uuids
+                workflow_uuids=workflow_uuids, operation_uuids=operation_uuids, api_name=api_name
             )
-            # Inject api_name into each workflow entry
-            api_name_val = request.get("api_name")
-            for wf_conf in result.get("workflows", {}).values():
-                wf_conf["api_name"] = api_name_val
-
             return {"result": result}
 
         except ValueError as e:
@@ -90,6 +92,7 @@ class MCPAdapter:
                     "success": False,
                     "operation_uuids": operation_uuids,
                     "workflow_uuids": workflow_uuids,
+                    "api_name": api_name,
                     "message": str(e),
                     "config": {},
                 }


### PR DESCRIPTION
This commit improves the handling of API names in the MCP adapter:

Fixes incorrect API name propagation in generate_runtime_config method to correctly handle operations without hardcoded path-based logic

Refactors _ensure_api_names_in_response by extracting common logic into a helper method (_extract_api_name_from_refs)

Ensures consistent API name handling for both operations and workflows

Bumps version from 0.6.4 to 0.6.5

The changes preserve the existing behavior while making the code more maintainable and reducing duplication. This fixes issues with vendor name prefixing and ensures proper API referencing for operations like Discord message interactions.