### PR TITLE
Fix - Updating SDK

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.5"
+version = "0.6.6"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.12",
+    "jentic >=0.7.13",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Ensuring SDK no longer outputs the second api_name, ensuring only the inner api_name remains.