### PR TITLE
Update oak-runner to 0.8.9 in python package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jentic"
 
-version = "0.7.13"
+version = "0.7.14"
 
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
@@ -12,7 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonpath-ng>=1.5.0",
     "httpx>=0.28.1",
-    "oak-runner>=0.8.7"
+    "oak-runner>=0.8.9"
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Update oak-runner dependency from >=0.8.7 to >=0.8.9
- Bump jentic package version from 0.7.13 to 0.7.14