### PR TITLE
Update jentic dependency to 0.7.14 in mcp package

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.6"
+version = "0.6.7"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.13",
+    "jentic >=0.7.14",
 ]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Update jentic dependency from >=0.7.13 to >=0.7.14
- Bump jentic-mcp package version from 0.6.6 to 0.6.7