### PR TITLE
fix/check operation success status

### DIFF
--- a/mcp/pdm.lock
+++ b/mcp/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c837078fc15916cd2898196ab3a626253dbdad29a91a3352621e08b2d818c317"
+content_hash = "sha256:3d5b45c59ec8d51b5e08c3e469a6387eeee42cca8f918659d2fe6bcf8bd69b03"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -287,7 +287,7 @@ files = [
 
 [[package]]
 name = "jentic"
-version = "0.7.14"
+version = "0.8.0"
 requires_python = ">=3.10"
 summary = "Jentic SDK for the discovery and execution of APIs and workflows"
 groups = ["default"]
@@ -299,8 +299,8 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 files = [
-    {file = "jentic-0.7.14-py3-none-any.whl", hash = "sha256:dbddeebe965045eab4cb1186be0c281cf4b82b08a9fa3b0883e77bd5f0803b1c"},
-    {file = "jentic-0.7.14.tar.gz", hash = "sha256:260a47961ffe9032667e6429b64deed0971703ccc49f663ee628386b3537e247"},
+    {file = "jentic-0.8.0-py3-none-any.whl", hash = "sha256:9efbbffefdf5166f7d725dc4411ce69d6dd9ca1e1351c5a938fba901f12cb67e"},
+    {file = "jentic-0.8.0.tar.gz", hash = "sha256:fc3315a57786c7de6a96404ac9a31214f282c0470f4514b8814eef749938bd7e"},
 ]
 
 [[package]]

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jentic-mcp"
-version = "0.6.7"
+version = "0.6.8"
 description = "Jentic MCP Plugin Implementation"
 authors = [
     {name = "Jentic Labs", email = "info@jenticlabs.com"},
@@ -13,7 +13,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "fastapi>=0.103.1",
     "uvicorn>=0.23.2",
-    "jentic >=0.7.14",
+    "jentic>=0.8.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/mcp/src/mcp/adapters/mcp.py
+++ b/mcp/src/mcp/adapters/mcp.py
@@ -168,8 +168,17 @@ class MCPAdapter:
         try:
             if execution_type == "operation":
                 result = await self.jentic.execute_operation(operation_uuid=uuid, inputs=inputs)
-                # Operations typically return a dict
-                return {"result": {"success": True, "output": result}}
+                if hasattr(result, 'success') and not result.success:
+                    return {
+                        "result": {
+                                "success": False,
+                                 "message": result.error or "Operation execution failed.",
+                                 "output": asdict(result),
+                                 "suggested_next_actions": self.get_execute_tool_failure_suggested_next_actions()
+                             }
+                    }
+
+                return {"result": {"success": True, "output": asdict(result)}}
             elif execution_type == "workflow":
                 result = await self.jentic.execute_workflow(workflow_uuid=uuid, inputs=inputs)
                 # Check the success value in the WorkflowResult


### PR DESCRIPTION
This PR changes the MCP behaviour so that it returns the correct status after an operation execution. It has access to this flag as of `jentic 0.8.0`. See: https://github.com/jentic/jentic-tools/pull/32