### PR TITLE
Adds SDK support for vendor filtering

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jentic"
 
-version = "0.8.0"
+version = "0.8.1"
 
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [

--- a/python/src/jentic/api/api_hub.py
+++ b/python/src/jentic/api/api_hub.py
@@ -419,6 +419,9 @@ class JenticAPIClient:
             keyword_str = " ".join(request.keywords)
             search_request["query"] = f"{search_request['query']} {keyword_str}"
 
+        if request.api_names:
+            search_request["api_names"] = request.api_names
+
         logger.info(f"Searching all entities with query: {search_request['query']}")
 
         # Log the URL we're connecting to for debugging

--- a/python/src/jentic/models.py
+++ b/python/src/jentic/models.py
@@ -74,6 +74,7 @@ class ApiCapabilitySearchRequest(BaseModel):
     capability_description: str
     keywords: list[str] | None = None
     max_results: int = 5
+    api_names: list[str] | None = None
 
 
 class BaseSearchResult(BaseModel):


### PR DESCRIPTION
[This is the SDK commit & merge]

Implements support for exact-match `api_names` filtering (e.g. `google.com`, `google.com/sheets`) in: • Jentic SDK – add optional `api_names` to `ApiCapabilitySearchRequest` and forward to Directory API. • MCP server – expose `api_names` in `search_apis` tool schema and adapter. Agents can now restrict results to specific APIs when the exact vendor or sub-API is known. Fuzzy vendor matching is intentionally **not** included.

This builds on the work of: https://jentic.atlassian.net/browse/JENTICPROD-360 & https://github.com/jentic/jentic-directory-api/pull/35