### PR TITLE
Update arazzo-runner to 0.8.18 and bump SDK to 0.8.4

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "jentic"
 
-version = "0.8.3"
+version = "0.8.4"
 
 description = "Jentic SDK for the discovery and execution of APIs and workflows"
 authors = [
@@ -12,7 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "jsonpath-ng>=1.5.0",
     "httpx>=0.28.1",
-    "arazzo-runner>=0.8.17"
+    "arazzo-runner>=0.8.18"
 ]
 requires-python = ">=3.11"
 readme = "README.md"


### PR DESCRIPTION
Updates arazzo-runner dependency to version 0.8.18 and increments the Python SDK version to 0.8.4.